### PR TITLE
Fixed type of “id” parameter for LabelEntity: datasets/mmdataset.py "add_labels"

### DIFF
--- a/mmseg/apis/ote/extension/datasets/mmdataset.py
+++ b/mmseg/apis/ote/extension/datasets/mmdataset.py
@@ -22,6 +22,7 @@ from ote_sdk.utils.segmentation_utils import mask_from_dataset_item
 from ote_sdk.entities.annotation import Annotation, AnnotationSceneEntity, AnnotationSceneKind
 from ote_sdk.entities.dataset_item import DatasetItemEntity
 from ote_sdk.entities.datasets import DatasetEntity
+from ote_sdk.entities.id import ID
 from ote_sdk.entities.image import Image
 from ote_sdk.entities.label import LabelEntity, Domain
 from ote_sdk.entities.scored_label import ScoredLabel
@@ -286,7 +287,7 @@ def add_labels(cur_labels, new_labels):
             label_id = label_id if label_id is not None else len(cur_labels)
             label = LabelEntity(name=label_name,
                                 domain=Domain.SEGMENTATION,
-                                id=label_id)
+                                id=ID(label_id))
             cur_labels.append(label)
 
 

--- a/mmseg/apis/ote/extension/datasets/mmdataset.py
+++ b/mmseg/apis/ote/extension/datasets/mmdataset.py
@@ -287,7 +287,7 @@ def add_labels(cur_labels, new_labels):
             label_id = label_id if label_id is not None else len(cur_labels)
             label = LabelEntity(name=label_name,
                                 domain=Domain.SEGMENTATION,
-                                id=ID(label_id))
+                                id=ID(f"{label_id:08}"))
             cur_labels.append(label)
 
 


### PR DESCRIPTION
Due to upcoming changes in input parameters validation for OTE SDK entities in Pull Request https://github.com/openvinotoolkit/training_extensions/pull/890:
•	Changed type of “id” initialization parameter of “LabelEntity” object from integer to expected ID in “add_labels” function

Task: CVS-77297