### PR TITLE
implement time_monitor to return score for HPO

### DIFF
--- a/configs/ote/custom-sematic-segmentation/ocr-lite-hrnet-18/hpo_config.yaml
+++ b/configs/ote/custom-sematic-segmentation/ocr-lite-hrnet-18/hpo_config.yaml
@@ -1,0 +1,17 @@
+metric: mDice
+search_algorithm: smbo
+early_stop: None
+max_iterations: 30
+hp_space:
+  learning_parameters.learning_rate:
+    param_type: quniform
+    range: 
+      - 0.001
+      - 0.1
+      - 0.001
+  learning_parameters.batch_size:
+    param_type: qloguniform
+    range:
+      - 4
+      - 8
+      - 2

--- a/mmseg/apis/ote/apis/segmentation/ote_utils.py
+++ b/mmseg/apis/ote/apis/segmentation/ote_utils.py
@@ -47,11 +47,10 @@ class TrainingProgressCallback(TimeMonitorCallback):
         score = None
         if hasattr(self.update_progress_callback, 'metric') and isinstance(logs, dict):
             score = logs.get(self.update_progress_callback.metric, None)
+            if score is not None:
+                score = float(score)
 
-        if score is not None:
-            self.update_progress_callback(self.get_progress(), score=float(score))
-        else:
-            self.update_progress_callback(int(self.get_progress()))
+        self.update_progress_callback(self.get_progress(), score=score)
 
 
 class InferenceProgressCallback(TimeMonitorCallback):

--- a/mmseg/apis/ote/extension/utils/hooks.py
+++ b/mmseg/apis/ote/extension/utils/hooks.py
@@ -149,7 +149,7 @@ class OTEProgressHook(Hook):
         self.time_monitor.on_epoch_begin(runner.epoch)
 
     def after_epoch(self, runner):
-        self.time_monitor.on_epoch_end(runner.epoch)
+        self.time_monitor.on_epoch_end(runner.epoch, runner.log_buffer.output)
 
     def before_iter(self, runner):
         self.time_monitor.on_train_batch_begin(1)


### PR DESCRIPTION
This PR contains changes for HPO.

There are two changes.
1. Add _hpo_config.yaml_ into OTE model directory.
2. Implement code flow to provide model score per epoch using Callback class.