### PR TITLE
Update nncf runner

### DIFF
--- a/mmseg/integration/nncf/runners.py
+++ b/mmseg/integration/nncf/runners.py
@@ -11,7 +11,7 @@ from mmcv.runner.utils import get_host_info
 from .utils import check_nncf_is_enabled
 
 
-@RUNNERS.register_module()
+@RUNNERS.register_module(force=True)
 class AccuracyAwareRunner(EpochBasedRunner):
     """
     An mmdet training runner to be used with NNCF-based accuracy-aware training.


### PR DESCRIPTION
Hello, we've missed a module about allowing registration of existing hook. 

- added 'force=True' arg to hook registration decorator, same with previous PR #55.

Signed-off-by: Jihwan Eom [jihwan.eom@intel.com](mailto:jihwan.eom@intel.com)