### PR TITLE
Fixed type of “id” parameter for LabelEntity: mmdataset.py

### DIFF
--- a/mmseg/apis/ote/extension/datasets/mmdataset.py
+++ b/mmseg/apis/ote/extension/datasets/mmdataset.py
@@ -263,7 +263,7 @@ def create_annotation_from_hard_seg_map(hard_seg_map: np.ndarray, labels: List[L
             annotations.append(Annotation(
                     Polygon(points=points),
                     labels=[ScoredLabel(label)],
-                    id=label_id,
+                    id=ID(f"{label_id:08}"),
             ))
 
     return annotations


### PR DESCRIPTION
Due to upcoming changes in input parameters validation for OTE SDK entities in Pull Request https://github.com/openvinotoolkit/training_extensions/pull/890:
•	mmseg/apis/ote/extension/datasets/mmdataset.py: Changed type of “id” initialization parameter of “LabelEntity” object from integer to expected ID in “create_annotation_from_hard_seg_map” function
Results with upcoming input parameters validation: ote-test/1019/ (mmdetection + mmsegmentation backends)
