### PR TITLE
fix bug related to resume

### DIFF
--- a/mmseg/apis/train.py
+++ b/mmseg/apis/train.py
@@ -262,9 +262,13 @@ def train_segmentor(model,
     if validate:
         eval_cfg = cfg.get('evaluation', {})
         eval_cfg['by_epoch'] = cfg.runner['type'] != 'IterBasedRunner'
-        if "resume_from" in cfg:
-            eval_cfg['best_ckpt_path'] = osp.join(cfg.work_dir,
-                osp.basename(cfg.get('resume_from')))
+        if cfg.get('resume_from') is not None:
+            eval_cfg['best_ckpt_path'] = osp.join(
+                cfg.work_dir,
+                osp.basename(cfg['resume_from'])
+            )
+        else:
+            eval_cfg['best_ckpt_path'] = None
         eval_hook = DistEvalHook if distributed else EvalHook
         if nncf_enable_compression:
             # disable saving best snapshot, because it works incorrectly for NNCF,

--- a/mmseg/core/evaluation/eval_hooks.py
+++ b/mmseg/core/evaluation/eval_hooks.py
@@ -29,10 +29,12 @@ class EvalHook(_EvalHook):
     greater_keys = ['mIoU', 'mAcc', 'aAcc', 'mDice']
 
     def __init__(self, *args, by_epoch=False, efficient_test=False, **kwargs):
+        best_ckpt_path = kwargs.get("best_ckpt_path")
+        if "best_ckpt_path" in kwargs:
+            kwargs.pop("best_ckpt_path")
         super().__init__(*args, by_epoch=by_epoch, **kwargs)
         self.efficient_test = efficient_test
-        if "best_ckpt_path" in kwargs:
-            self.best_ckpt_path = kwargs["best_ckpt_path"]
+        self.best_ckpt_path = best_ckpt_path
 
     def _do_evaluate(self, runner):
         """perform evaluation and save ckpt."""
@@ -85,10 +87,12 @@ class DistEvalHook(_DistEvalHook):
     greater_keys = ['mIoU', 'mAcc', 'aAcc', 'mDice']
 
     def __init__(self, *args, by_epoch=False, efficient_test=False, **kwargs):
+        best_ckpt_path = kwargs.get("best_ckpt_path")
+        if "best_ckpt_path" in kwargs:
+            kwargs.pop("best_ckpt_path")
         super().__init__(*args, by_epoch=by_epoch, **kwargs)
         self.efficient_test = efficient_test
-        if "best_ckpt_path" in kwargs:
-            self.best_ckpt_path = kwargs["best_ckpt_path"]
+        self.best_ckpt_path = best_ckpt_path
 
     def _do_evaluate(self, runner):
         """perform evaluation and save ckpt."""


### PR DESCRIPTION
- modify to save correct resume weight path
- add code to save hook_msg from resume weight which is already updated in mmcv 1.3.14
- pass kwargs argument to parent of eval_hook class except best_ckpt_path to avoid possible confliction