### PR TITLE
fix bug about label_map

### DIFF
--- a/mmseg/core/evaluation/metrics.py
+++ b/mmseg/core/evaluation/metrics.py
@@ -70,8 +70,9 @@ def intersect_and_union(pred_label,
         label = torch.from_numpy(label)
 
     if label_map is not None:
+        label_copy = label.clone()
         for old_id, new_id in label_map.items():
-            label[label == old_id] = new_id
+            label[label_copy == old_id] = new_id
     if reduce_zero_label:
         label[label == 0] = 255
         label = label - 1

--- a/mmseg/datasets/pipelines/loading.py
+++ b/mmseg/datasets/pipelines/loading.py
@@ -134,8 +134,12 @@ class LoadAnnotations(object):
             backend=self.imdecode_backend).squeeze().astype(np.uint8)
         # modify if custom classes
         if results.get('label_map', None) is not None:
+            # Add deep copy to solve bug of repeatedly
+            # replace `gt_semantic_seg`, which is reported in
+            # https://github.com/open-mmlab/mmsegmentation/pull/1445/
+            gt_semantic_seg_copy = gt_semantic_seg.copy()
             for old_id, new_id in results['label_map'].items():
-                gt_semantic_seg[gt_semantic_seg == old_id] = new_id
+                gt_semantic_seg[gt_semantic_seg_copy == old_id] = new_id
         # reduce zero_label
         if self.reduce_zero_label:
             # avoid using underflow conversion


### PR DESCRIPTION
As reported in https://github.com/open-mmlab/mmsegmentation/pull/1445, there is a bug when converting label using complex `label_map`.

ex1)
```python
label_map = {6: 9, 9: 7}
expect : 6 -> 9 / 9 -> 7
real : 6 -> 9 (O) / 9 (=new 9 which was 6 before + original 9) -> 7 (X)
```

ex2)
```python
label_map = {2: 3, 3: -1}
expect : 2 -> 3 / 3 -> -1
real : 2 -> 3 (O) / 3 (=new 3 which was 2 before + original 3) -> -1 (X)
```